### PR TITLE
Use format message from plottr locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "plttr_translation",
+  "name": "plottr_locales",
   "version": "0.0.1",
   "description": "A repository of all messages in Plottr with their translations into other languages",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -45,4 +45,5 @@ module.exports = {
   localeNames,
   setupI18n,
   getCurrentLocale,
+  formatMessage: i18n,
 }


### PR DESCRIPTION
# Re Export Format Message from `plottr_locales`
We either need to declare `format-message` as peer dependency and rely on each dependant to import it correctly, or we need to export the correct `format-message` from here.
The problem is that when we configure a `format-message`, the package in that projects node modules is configured.
Having it as a dependency in many places opens us to conflicting versions creating problems down the line.